### PR TITLE
Add edition2024 to cargo-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lch-mnky-rs"
 version = "0.1.0"
 edition = "2024"
+cargo-features = ["edition2024"]
 
 [workspace]
 members = ["lexer", "parser", "repl"]


### PR DESCRIPTION
This commit adds the `edition2024` feature to the `cargo-features` array in the top-level `Cargo.toml` file. This enables testing of the upcoming 2024 Rust edition.