### PR TITLE
Add cargo-features for Edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "lch-mnky-rs"
 version = "0.1.0"

--- a/lexer/Cargo.toml
+++ b/lexer/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "lexer"
 version = "0.1.0"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "parser"
 version = "0.1.0"

--- a/repl/Cargo.toml
+++ b/repl/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "repl"
 version = "0.1.0"


### PR DESCRIPTION
This commit adds the `cargo-features = ["edition2024"]` line to the top of all Cargo.toml files in the project. This enables features specific to the Rust 2024 edition.