### PR TITLE
Enable optional serial testing

### DIFF
--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -14,6 +14,7 @@ derive_more = { version = "2.0.1", features = ["display"] }
 serial_test = "3.2.0"
 
 [features]
-default = ["indent-log"]
-indent-log = []
-serial = []
+#default = ["indent-log"]
+default = []
+indent-log = ["serial-test"]
+serial-test = []

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -9,9 +9,10 @@ log = "0.4.27"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 derive_more = { version = "2.0.1", features = ["display"] }
+serial_test = "3.2.0"
 
 [dev-dependencies]
-serial_test = "3.2.0"
+
 
 [features]
 #default = ["indent-log"]

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -16,3 +16,4 @@ serial_test = "3.2.0"
 [features]
 default = ["indent-log"]
 indent-log = []
+serial = []

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -299,6 +299,7 @@ mod test {
     use lexer::lexer::Lexer;
     use lexer::token::Token;
     use log::info;
+    #[cfg(feature = "serial")]
     use serial_test::serial;
 
     use crate::ast::Expr::NoImpl;
@@ -307,7 +308,7 @@ mod test {
     use crate::parser::Parser;
 
     #[test]
-    #[serial]
+    #[cfg_attr(feature = "serial", serial)]
     fn test_let_stmt() {
         init_logger();
 
@@ -342,7 +343,7 @@ mod test {
     }
 
     #[test]
-    #[serial]
+    #[cfg_attr(feature = "serial", serial)]
     fn test_return_stmt() {
         init_logger();
 
@@ -363,7 +364,7 @@ mod test {
     }
 
     #[test]
-    #[serial]
+    #[cfg_attr(feature = "serial", serial)]
     fn test_ident_expr() {
         init_logger();
 
@@ -389,7 +390,7 @@ mod test {
     }
 
     #[test]
-    #[serial]
+    #[cfg_attr(feature = "serial", serial)]
     fn test_int_literal() {
         init_logger();
 
@@ -415,7 +416,7 @@ mod test {
     }
 
     #[test]
-    #[serial]
+    #[cfg_attr(feature = "serial", serial)]
     fn test_prefix_expr() {
         init_logger();
 
@@ -431,7 +432,7 @@ mod test {
     }
 
     #[test]
-    #[serial]
+    #[cfg_attr(feature = "serial", serial)]
     fn test_infix_expr() {
         init_logger();
 

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1,7 +1,3 @@
-use lexer::lexer::Lexer;
-use lexer::token::Token;
-use log::warn;
-
 use crate::ast::Expr::NoImpl;
 use crate::ast::Precedence::Prefix;
 use crate::ast::{
@@ -9,6 +5,11 @@ use crate::ast::{
     ReturnStmt, Stmt,
 };
 use crate::{enter, info};
+use lexer::lexer::Lexer;
+use lexer::token::Token;
+use log::warn;
+#[cfg(feature = "serial-test")]
+use serial_test::serial;
 
 #[derive(Debug)]
 pub struct Parser {
@@ -294,10 +295,9 @@ impl TakeAndLogToken for Option<Token> {
     }
 }
 
+#[cfg_attr(feature = "serial-test", serial)]
 #[cfg(test)]
 mod test {
-    #[cfg(feature = "serial-test")]
-    use crate::ast::Expr::NoImpl;
     use crate::ast::Expr::NoImpl;
     use crate::ast::{Expr, ExprStmt, IdentExpr, IntLiteral, LetStmt, Program, ReturnStmt, Stmt};
     use crate::init_logger;
@@ -307,7 +307,6 @@ mod test {
     use log::info;
 
     #[test]
-    #[cfg_attr(feature = "serial-test", serial)]
     fn test_let_stmt() {
         init_logger();
 
@@ -342,7 +341,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(feature = "serial-test", serial)]
     fn test_return_stmt() {
         init_logger();
 
@@ -363,7 +361,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(feature = "serial-test", serial)]
     fn test_ident_expr() {
         init_logger();
 
@@ -389,7 +386,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(feature = "serial-test", serial)]
     fn test_int_literal() {
         init_logger();
 
@@ -415,7 +411,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(feature = "serial-test", serial)]
     fn test_prefix_expr() {
         init_logger();
 
@@ -431,7 +426,6 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(feature = "serial-test", serial)]
     fn test_infix_expr() {
         init_logger();
 

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -42,7 +42,7 @@ impl Parser {
         let mut program = Program::new();
 
         while let Some(ref token) = self.curr_token {
-            info!("=====> {token}");
+            info!("Process token {token}");
 
             match token {
                 Token::EOF => break,
@@ -296,19 +296,18 @@ impl TakeAndLogToken for Option<Token> {
 
 #[cfg(test)]
 mod test {
-    use lexer::lexer::Lexer;
-    use lexer::token::Token;
-    use log::info;
-    #[cfg(feature = "serial")]
-    use serial_test::serial;
-
+    #[cfg(feature = "serial-test")]
+    use crate::ast::Expr::NoImpl;
     use crate::ast::Expr::NoImpl;
     use crate::ast::{Expr, ExprStmt, IdentExpr, IntLiteral, LetStmt, Program, ReturnStmt, Stmt};
     use crate::init_logger;
     use crate::parser::Parser;
+    use lexer::lexer::Lexer;
+    use lexer::token::Token;
+    use log::info;
 
     #[test]
-    #[cfg_attr(feature = "serial", serial)]
+    #[cfg_attr(feature = "serial-test", serial)]
     fn test_let_stmt() {
         init_logger();
 
@@ -343,7 +342,7 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(feature = "serial", serial)]
+    #[cfg_attr(feature = "serial-test", serial)]
     fn test_return_stmt() {
         init_logger();
 
@@ -364,7 +363,7 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(feature = "serial", serial)]
+    #[cfg_attr(feature = "serial-test", serial)]
     fn test_ident_expr() {
         init_logger();
 
@@ -390,7 +389,7 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(feature = "serial", serial)]
+    #[cfg_attr(feature = "serial-test", serial)]
     fn test_int_literal() {
         init_logger();
 
@@ -416,7 +415,7 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(feature = "serial", serial)]
+    #[cfg_attr(feature = "serial-test", serial)]
     fn test_prefix_expr() {
         init_logger();
 
@@ -432,7 +431,7 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(feature = "serial", serial)]
+    #[cfg_attr(feature = "serial-test", serial)]
     fn test_infix_expr() {
         init_logger();
 


### PR DESCRIPTION
## Summary
- make `serial_test` optional via a new `serial` feature
- gate the `serial` attribute in parser tests behind the feature

## Testing
- `cargo test -p parser`
- `cargo test -p parser --features serial`

------
https://chatgpt.com/codex/tasks/task_e_68432899d9748333851eea5e93f44783