### PR TITLE
Remove unnecessary pub on parser functions

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -72,7 +72,7 @@ impl Parser {
         program
     }
 
-    pub fn parse_let_stmt(&mut self) -> Option<Stmt> {
+    fn parse_let_stmt(&mut self) -> Option<Stmt> {
         enter!("[LetStmt]");
 
         assert!(
@@ -115,7 +115,7 @@ impl Parser {
         Some(Stmt::Let(LetStmt::new(Token::Let, identifier, expr)))
     }
 
-    pub fn parse_return_stmt(&mut self) -> Option<Stmt> {
+    fn parse_return_stmt(&mut self) -> Option<Stmt> {
         enter!("[ReturnStmt]");
         assert!(
             matches!(self.curr_token, Some(Token::Return)),
@@ -137,7 +137,7 @@ impl Parser {
         Some(Stmt::Return(ReturnStmt::new(Token::Return, expr)))
     }
 
-    pub fn parse_expr_stmt(&mut self) -> Option<Stmt> {
+    fn parse_expr_stmt(&mut self) -> Option<Stmt> {
         enter!("[ExprStmt]");
         let stmt = self
             .parse_expr(Precedence::Lowest)


### PR DESCRIPTION
## Summary
- restrict visibility of parser functions now only used internally
- keep Parser::new and parse_program public for API use

## Testing
- `cargo check`
- `cargo test --workspace --no-run`


------
https://chatgpt.com/codex/tasks/task_e_68439aa8dc5483339c042deafb18d312