### PR TITLE
Refactor IfExpr structure

### DIFF
--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -175,24 +175,24 @@ impl fmt::Display for BoolLiteral {
 pub struct IfExpr {
     pub token: Token,
     pub condition: Box<Expr>,
-    pub consequence: Box<BlockStmt>,
-    pub alternative: Option<Box<BlockStmt>>,
+    pub consequence: BlockStmt,
+    pub alternative: Option<BlockStmt>,
 }
 impl IfExpr {
     pub fn new(condition: Expr, consequence: BlockStmt, alternative: Option<BlockStmt>) -> Self {
         Self {
             token: Token::If,
             condition: Box::new(condition),
-            consequence: Box::new(consequence),
-            alternative: alternative.map(Box::new),
+            consequence,
+            alternative,
         }
     }
 }
 impl fmt::Display for IfExpr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut result = format!("if ({}) {}", self.condition, self.consequence.as_ref());
+        let mut result = format!("if ({}) {}", self.condition, self.consequence);
         if let Some(alternative) = &self.alternative {
-            result.push_str(&format!(" else {}", alternative.as_ref()));
+            result.push_str(&format!(" else {}", alternative));
         }
         write!(f, "{}", result)
     }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,11 +1,13 @@
 use std::cell::RefCell;
 use std::sync::Once;
 use tracing::Level;
-use tracing_subscriber::FmtSubscriber;
 use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::FmtSubscriber;
 
 pub mod ast;
 pub mod parser;
+#[cfg(test)]
+mod test_utils;
 
 static INIT: Once = Once::new();
 pub fn init_logger() {

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -364,6 +364,7 @@ mod test {
     };
     use crate::init_logger;
     use crate::parser::Parser;
+    use crate::test_utils::new_ident;
     use lexer::lexer::Lexer;
     use lexer::token::Token;
     use log::info;
@@ -392,11 +393,7 @@ mod test {
             LetStmt::new(
                 Token::Let,
                 IdentExpr::new(Token::Identifier("result".to_string())),
-                Expr::Infix(InfixExpr::new(
-                    Token::Plus,
-                    Expr::Ident(IdentExpr::new(Token::Identifier("x".to_string()))),
-                    Expr::Ident(IdentExpr::new(Token::Identifier("y".to_string()))),
-                )),
+                Expr::Infix(InfixExpr::new(Token::Plus, new_ident("x"), new_ident("y"))),
             ),
         ];
 

--- a/parser/src/test_utils.rs
+++ b/parser/src/test_utils.rs
@@ -1,0 +1,23 @@
+use crate::ast::{BoolLiteral, Expr, IdentExpr, IntLiteral};
+use lexer::token::Token;
+
+#[cfg(test)]
+pub fn new_ident(name: &str) -> Expr {
+    Expr::Ident(IdentExpr::new(Token::Identifier(name.to_string())))
+}
+
+#[cfg(test)]
+pub fn new_bool(value: bool) -> Expr {
+    Expr::Bool(BoolLiteral::new(
+        match value {
+            true => Token::True,
+            false => Token::False,
+        },
+        value,
+    ))
+}
+
+#[cfg(test)]
+pub fn new_int(value: i64) -> Expr {
+    Expr::Int(IntLiteral::new(Token::Int(value.to_string()), value))
+}


### PR DESCRIPTION
## Summary
- drop `Box` wrapper on `IfExpr` `consequence` and `alternative`

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_68454ae33bf08333b6200c9a036133aa